### PR TITLE
Fix ICMP DNAT generation for IPv6

### DIFF
--- a/src/shorewall_nft/emit.py
+++ b/src/shorewall_nft/emit.py
@@ -896,11 +896,15 @@ class Emitter:
         return _priority_token(spec, self.named_priority)
 
     def _nat_fam(self, ipkw):
-        """The family qualifier before a nat 'to' (e.g. 'ip ' or 'ip6 '),
-        kept where the nft accepts it and dropped on nft 0.9.0, which has no
-        'dnat ip to' form. Plain 'dnat to' loads on every nft. The netmap
-        prefix form keeps its qualifier and is gated separately."""
-        return f"{ipkw} " if self.nat_family else ""
+        """The optional family qualifier before a nat ``to``.
+
+        nft accepts ``dnat ip to`` for IPv4, but its NAT grammar has no
+        corresponding ``dnat ip6 to`` form.  IPv6 targets are unambiguous in
+        an ip6 table, so emit the portable plain ``dnat to``/``snat to`` form
+        there.  Old nft also needs the plain form for IPv4.  The netmap prefix
+        form is separate and keeps its required qualifier.
+        """
+        return "ip " if self.nat_family and ipkw == "ip" else ""
 
     def render(self):
         cfg = self.cfg
@@ -2291,7 +2295,15 @@ class Emitter:
             if d.origdest:
                 m.append(f"{ipkw} daddr "
                          f"{_addr_or_ifaddr(d.origdest, self.ifmap, self.sets)}")
-            if "," in d.proto:
+            proto = d.proto.lower()
+            if d.dport and proto in ("icmp", "1"):
+                icmp_type = ICMP_TYPES.get(d.dport.lower(), d.dport)
+                m.append(f"icmp type {icmp_type}")
+            elif d.dport and proto in ICMP6_PROTOS:
+                # Shorewall macros carry the ICMP type in their historical
+                # DEST PORT column. It is an ICMP type, not an L4 port.
+                m.append(f"icmpv6 type {d.dport.lower()}")
+            elif "," in d.proto:
                 protos = "{ " + ", ".join(d.proto.split(",")) + " }"
                 m.append(f"meta l4proto {protos}")
                 if d.dport:

--- a/tests/harness/forms-unit.py
+++ b/tests/harness/forms-unit.py
@@ -698,6 +698,28 @@ form_ok("rules: DNAT honours the RATE LIMIT column",
          "rules": "?SECTION NEW\nDNAT net loc:10.0.0.9 tcp 80 - - 10/min:5\n"},
         expect="limit rate 10/minute burst 5 packets dnat ip to 10.0.0.9")
 
+# nft's NAT grammar accepts the optional `ip` family qualifier but not an
+# `ip6` counterpart.  This surfaced with a Ping/DNAT macro because the parser
+# rejected `dnat ip6 to` after successfully parsing the ICMPv6 match.  Keep an
+# IPv4 twin here to ensure fixing IPv6 does not remove its supported qualifier.
+form_ok("rules: Ping/DNAT uses the valid unqualified IPv6 NAT form",
+        {"zones": "fw firewall\nnet ipv6\nlxbr0 ipv6\n",
+         "interfaces": "?FORMAT 2\nnet eth0\nlxbr0 lxbr0\n",
+         "policy": "$FW net ACCEPT\nnet all DROP\nall all REJECT\n",
+         "params": ('acme="[fc42:5009:ba4b:5ab0::202]"\n'
+                    'acmednat="[2407:3641:2298:1223::202]"\n'),
+         "rules": ("?SECTION NEW\n"
+                   "Ping/DNAT net lxbr0:$acme - - - $acmednat\n")},
+        family=6,
+        expect="icmpv6 type 128 dnat to fc42:5009:ba4b:5ab0::202")
+form_ok("rules: Ping/DNAT retains the valid IPv4 NAT family qualifier",
+        {"zones": "fw firewall\nnet ipv4\nloc ipv4\n",
+         "interfaces": "?FORMAT 2\nnet eth0\nloc eth1\n",
+         "params": ('server="10.0.0.202"\n'
+                    'public="192.0.2.202"\n'),
+         "rules": "?SECTION NEW\nPing/DNAT net loc:$server - - - $public\n"},
+        expect="icmp type echo-request dnat ip to 10.0.0.202")
+
 # --- conntrack: the stock /etc/shorewall/conntrack file ships on every
 # install. It is ?FORMAT 3 and assigns conntrack helpers, gated on the
 # AUTOHELPERS setting and the helper capabilities. Migrating any real system


### PR DESCRIPTION
## Fix Ping/DNAT rules for IPv6 and clean up ICMP NAT matching.

A rule such as
`Ping/DNAT net lxbr0:$mycontainer - - - $mycontainerdnat`
previously generated
`ipv6-icmp dport 128 dnat ip6 to fc42:5009:ba4b:5ab0::202`
which nft rejected.

The compiler now generates
`icmpv6 type 128 dnat to fc42:5009:ba4b:5ab0::202`.

This change omits the unsupported NAT family qualifier for IPv6 while preserving `dnat ip to` and `snat ip to` for IPv4. It also renders Shorewall’s historical ICMP destination-port values as native `icmp type` or `icmpv6 type` matches, reflecting that these values represent ICMP message types rather than transport-layer ports.

IPv4 and IPv6 Ping/DNAT regression tests have been added.
Ordinary TCP DNAT output remains unchanged.

The generated output was verified for IPv6 Ping/DNAT, explicit IPv6 ICMP DNAT without a type, IPv4 Ping/DNAT, and IPv4 TCP DNAT.
Python compilation and `git diff --check` pass.
A fresh Debian package was also built and inspected to confirm it contains the changes.